### PR TITLE
prefer esperanto to es6-module-transpiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "broccoli-caching-writer": "0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
     "es6-module-transpiler": "^0.3.6",
+    "esperanto": "^0.6.3",
     "mkdirp": "^0.5.0",
     "walk-sync": "^0.1.3"
   },

--- a/test/expected/inner/first.js
+++ b/test/expected/inner/first.js
@@ -1,17 +1,17 @@
-define("inner/first", 
-  ["something","exports"],
-  function(__dependency1__, __exports__) {
-    "use strict";
-    var Something = __dependency1__["default"];
+define('inner/first', ['exports', '../something'], function (exports, Something) {
 
-    function meaningOfLife() {
-      new Something();
-      throw new Error(42);
-    }
+  'use strict';
 
-    __exports__.meaningOfLife = meaningOfLife;function boom() {
-      throw new Error('boom');
-    }
+  exports.meaningOfLife = meaningOfLife;
+  exports.boom = boom;
 
-    __exports__.boom = boom;
-  });
+  function meaningOfLife() {
+    new Something['default']();
+    throw new Error(42);
+  }
+
+  function boom() {
+    throw new Error('boom');
+  }
+
+});

--- a/test/expected/outer.js
+++ b/test/expected/outer.js
@@ -1,17 +1,15 @@
-define("outer", 
-  ["npm:vendor/monster","ember","exports"],
-  function(__dependency1__, __dependency2__, __exports__) {
-    "use strict";
-    var monster = __dependency1__["default"];
-    var Ember = __dependency2__["default"];
+define('outer', ['exports', 'npm:vendor/monster', 'ember'], function (exports, monster, Ember) {
 
-    __exports__["default"] = Ember.Route.extend({
-      actions: {
-        checkCookie: function() {
-          if (monster.get('magical')) {
-            alert('you have a magic cookie');
-          }
+  'use strict';
+
+  exports['default'] = Ember['default'].Route.extend({
+    actions: {
+      checkCookie: function() {
+        if (monster['default'].get('magical')) {
+          alert('you have a magic cookie');
         }
       }
-    });
+    }
   });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,11 @@
 var expect = require('chai').expect;  // jshint ignore:line
 var ES6 = require('..');
 var RSVP = require('rsvp');
-RSVP.on('error', function(err){throw err;});
+
+RSVP.on('error', function(err){
+  throw err;
+});
+
 var fs = require('fs');
 var path = require('path');
 var broccoli = require('broccoli');


### PR DESCRIPTION
- we get better spec compat (reasonable cycles work)
- it’s extremely fast

```
node ./benchmarks/modules-source-maps.js ./test-input/controller.js
running...
  - traceur x 360 ops/sec ±5.57% (74 runs sampled)
  - 6to5 (AMD) x 63.98 ops/sec ±5.54% (59 runs sampled)
  - 6to5 (CJS) x 61.93 ops/sec ±7.14% (54 runs sampled)
  - esperanto (AMD) x 197 ops/sec ±11.29% (66 runs sampled)
  - esperanto (CJS)  x 349 ops/sec ±5.76% (73 runs sampled)

node ./benchmarks/modules.js ./test-input/controller.js
running...
  - traceur x 297 ops/sec ±6.98% (71 runs sampled)
  - 6to5 (AMD) x 20.99 ops/sec ±6.84% (40 runs sampled)
  - 6to5 (CJS) x 19.26 ops/sec ±12.74% (37 runs sampled)
  - esperanto (AMD) x 191 ops/sec ±20.73% (51 runs sampled)
  - esperanto (CJS)  x 898 ops/sec ±19.33% (51 runs sampled)
```

@eventualbuddha has been directing his energy there lately.

cc @rich-harris

- [ ] enable source maps (@ef4 does your concat stuff handle inline sourcemaps?)