### PR TITLE
Temporarily using custom es6-module-transpiler due to a named function export bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "broccoli-caching-writer": "0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
-    "es6-module-transpiler": "^0.3.6",
+    "es6-module-transpiler": "git://github.com/jayphelps/es6-module-transpiler#named-export-bug-dist",
     "mkdirp": "^0.5.0",
     "walk-sync": "^0.1.3"
   },

--- a/test/expected/inner/first.js
+++ b/test/expected/inner/first.js
@@ -9,7 +9,8 @@ define("inner/first",
       throw new Error(42);
     }
 
-    __exports__.meaningOfLife = meaningOfLife;function boom() {
+    __exports__.meaningOfLife = meaningOfLife;
+    function boom() {
       throw new Error('boom');
     }
 


### PR DESCRIPTION
*This is confusing to explain and understand. Please feel free to ask for clarification*

[es6-module-transpiler@v0.3.6](https://github.com/esnext/es6-module-transpiler) has a bug where when exporting a named function it assumed you always provided a semi-colon, which is unnecessary but it incorrectly consumed the next character regardless, causing possibly malformed output if the next character was not a newline. Notice how I also had to change the expected result in the test file, because it was previously incorrectly removing the newline, but no one noticed because it's superfluous.

The fix I made in the transpiler can be [found here](https://github.com/jayphelps/es6-module-transpiler/commit/5e2cecf0074cbce93ff73d406db4b74cb65d1f91#diff-82ebea2b88a9e916b2f36e4e32b7beb2L95) and includes tests to verify.

###### How this was discovered and why it matters
ember-cli now uses 6to5 and for reasons not fully understood, 6to5 will hoist singleline comments to the bottom of the parsing file; it's related to the transformation process not being 1:1, but I'm still waiting to hear back from them exactly why. I'm guessing they just punted on the complexity. Since your inline comments are now hoisted to the bottom, if you export a named function in ember-cli the first forward slash of the comment is stripped by es6-module-transpiler, causing the comment to become a malformed regex.

Using ember-cli, here's an example:
```javascript
export function foo() {
  // bar
}
```
outputs as:

```javascript
function foo() {}
__exports__.foo = foo;/ bar
```

You can see this bug for yourself with these two demos:
[ember-cli demo breakage](https://github.com/jayphelps/ember-cli-6to5-issue-example)
[es6-module-transpiler demo breakage isolated by itself](https://github.com/jayphelps/es6-module-transpiler-issue-example)

@rwjblue was informed and recommended I PR ember-cli-6to5 to not disable comments (cause I initially thought it was only comment related) but after finding out it was broader, I thought it might be best to fix the actual issue until we can get off of v0.3.6 entirely, which we know is non-trivial.