### PR TITLE
Bump esperanto to v0.6.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "broccoli-caching-writer": "0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
-    "esperanto": "^0.6.4",
+    "esperanto": "^0.6.6",
     "mkdirp": "^0.5.0",
     "walk-sync": "^0.1.3"
   },


### PR DESCRIPTION
Fixes many issues (including one with reexports).