### PR TITLE
Use Esperanto's absolutePaths option to remove rewrite relative imports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ module.exports = CachingWriter.extend({
       return this.newTranspilerCache[key] = {
         amd: esperanto.toAmd(source, {
           amdName: moduleName,
+          absolutePaths: true,
           strict: true
         }).code
       };

--- a/test/expected/inner/first.js
+++ b/test/expected/inner/first.js
@@ -1,4 +1,4 @@
-define('inner/first', ['exports', '../something'], function (exports, Something) {
+define('inner/first', ['exports', 'something'], function (exports, Something) {
 
   'use strict';
 


### PR DESCRIPTION
See:

https://github.com/esperantojs/esperanto/issues/58
https://github.com/esperantojs/esperanto/pull/69