### PR TITLE
Allow users to specify esperantoOptions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,15 +47,31 @@ module.exports = CachingWriter.extend({
     }
     try {
       return this.newTranspilerCache[key] = {
-        amd: esperanto.toAmd(source, {
-          amdName: moduleName,
-          absolutePaths: true,
-          strict: true
-        }).code
+        amd: esperanto.toAmd(
+          source,
+          this.generateEsperantoOptions(moduleName)
+        ).code
       };
     } catch(err) {
       err.file = moduleName;
       throw err;
     }
+  },
+
+  generateEsperantoOptions: function(moduleName) {
+    var providedOptions = this.esperantoOptions || {};
+    var result = {
+      _evilES3SafeReExports: false,
+      absolutePaths: true,
+      strict: true
+    };
+
+    for (var keyName in providedOptions) {
+      result[keyName] = providedOptions[keyName];
+    }
+
+    result.amdName = moduleName;
+
+    return result;
   }
 });

--- a/test/expected/reexport-es3.js
+++ b/test/expected/reexport-es3.js
@@ -1,0 +1,9 @@
+define('reexport-es3', ['exports', 'inner/first'], function (exports, meaningOfLife) {
+
+	'use strict';
+
+
+
+	exports.meaningOfLife = meaningOfLife['default'];
+
+});

--- a/test/expected/reexport.js
+++ b/test/expected/reexport.js
@@ -1,0 +1,7 @@
+define('reexport', ['exports', 'inner/first'], function (exports, meaningOfLife) {
+
+	'use strict';
+
+	Object.defineProperty(exports, 'meaningOfLife', { enumerable: true, get: function () { return meaningOfLife['default']; }});
+
+});

--- a/test/fixtures/reexport-es3.js
+++ b/test/fixtures/reexport-es3.js
@@ -1,0 +1,5 @@
+import meaningOfLife from 'inner/first';
+
+export {
+	meaningOfLife
+}

--- a/test/fixtures/reexport.js
+++ b/test/fixtures/reexport.js
@@ -1,0 +1,5 @@
+import meaningOfLife from 'inner/first';
+
+export {
+	meaningOfLife
+}

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,21 @@ describe('broccoli-es6modules', function() {
     builder = new broccoli.Builder(tree);
     return builder.build().then(function(result) {
       expectFile('outer.js').in(result);
+      expectFile('reexport.js').in(result);
       expectFile('inner/first.js').in(result);
+    });
+  });
+
+  it('uses esperantoOptions if provided', function() {
+    var tree = new ES6(fixtures, {
+      esperantoOptions: {
+        _evilES3SafeReExports: true
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(result) {
+      expectFile('reexport-es3.js').in(result);
     });
   });
 


### PR DESCRIPTION
Prior to this change using broccoli-es6modules within an ember-cli app
that had re-exports (i.e. any app that uses an addon with an `addon/index.js`)
would be generating non-ES3 compatible output (due to the usage
`Object.defineProperty`).

This commit makes it possible to customize transpilation via
`esperantoOptions`, which allows generating ES3 safe output like:

```javascript
var es6 = new ES6(inputTree, {
  esperantoOptions: {
    _evilES3SafeReExports: true
  }
});
```