### PR TITLE
Bump minimum Esperanto version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "broccoli-caching-writer": "0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
-    "esperanto": "^0.6.7",
+    "esperanto": "^0.6.8",
     "mkdirp": "^0.5.0",
     "walk-sync": "^0.1.3"
   },


### PR DESCRIPTION
Contains a number of bugfixes:

* Ensure load order of import statements.
* Fix absolutePaths option with `./../`.