### PR TITLE
Ensure that `sourceMapFile` is set to the moduleName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ ES6Modules wraps the [esperanto](http://esperantojs.org/) library. All [options 
 esperanto](https://github.com/esperantojs/esperanto/wiki/Converting-a-single-module#options)
 can be provided here. All defaults are identical to those used by esperanto.
 
-Because the ES6Modules uses each file's name as its module name, the esperanto `amdName`
-option is ignored.
+Because the ES6Modules uses each file's name as its module name, the esperanto `amdName` and
+`sourceMapSource` options are ignored.
 
 ### bundleOptions
 ES6Modules wraps the [esperanto](http://esperantojs.org/) library. All [options described for

--- a/index.js
+++ b/index.js
@@ -100,8 +100,10 @@ module.exports = CachingWriter.extend({
 
     Some defaults are provided:
 
-    For per-file transpilations if the format is 'namedAmd', the 'amdName' option passed to the transpiler
-    for each file will be the files relative file path, with '.js' stripped from it.
+    * For per-file transpilations if the format is 'namedAmd', the 'amdName' option passed to the transpiler
+      for each file will be the files relative file path, with '.js' stripped from it.
+    * For per-file transpilations if `sourceMap` option is provided, the `sourceMapSource` option is passed
+      to the transpiler for each file as the relative file path, with '.js' stripped from it.
 
     So, if you have the following tree:
     ├── inner
@@ -248,9 +250,14 @@ module.exports = CachingWriter.extend({
       options.name = moduleName;
     }
 
+    if (providedOptions.sourceMap) {
+      options.sourceMapSource = moduleName;
+    }
+
     for (var keyName in providedOptions) {
       options[keyName] = providedOptions[keyName];
     }
+
 
     return options;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,18 @@ describe('broccoli-es6modules', function() {
     });
   });
 
+  it('sets sourceMapSource if source maps are enabled', function() {
+    var tree = new ES6(fixtures, {
+      esperantoOptions: {
+        sourceMap: 'inline'
+      }
+    });
+
+    var result = tree._generateEsperantoOptions('some-path/here');
+
+    expect(result.sourceMapSource).to.equal('some-path/here');
+  });
+
   it('compiles to cjs if format = cjs', function() {
     var tree = new ES6(fixtures, {
       format: 'cjs',


### PR DESCRIPTION
Sets `sourceMapFile` to the input `moduleName` if `sourceMap` is truthy.

This is required even for `inline` sourcemaps at the moment, but https://github.com/esperantojs/esperanto/issues/105 has been opened to potentially remove this requirement in Esperanto.