### PR TITLE
Bump caching-writer dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = CachingWriter.extend({
     and determine what method to delegate to esperanto for transpiling files.
   */
   init: function() {
+    this._super.init.apply(this, arguments);
     this._transpilerCache = {};
     this.toFormat = esperanto[formatToFunctionName[this.format]];
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Edward Faulkner <ef@alum.mit.edu>",
   "license": "MIT",
   "dependencies": {
-    "broccoli-caching-writer": "0.5.3",
+    "broccoli-caching-writer": "0.5.5",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
     "esperanto": "^0.6.8",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
The newer caching-writer uses core-object 0.0.3 instead of 0.0.2, so it seems we need to update `init`. @stefanpenner, is this `_super` call correct? I'm just guessing here.