### PR TITLE
Bump esperanto to ^v0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 #broccoli-es6modules
 
+[![Dependency Status](https://david-dm.org/ember-cli/broccoli-es6modules.svg)](https://david-dm.org/ember-cli/broccoli-es6modules)
+[![devDependency Status](https://david-dm.org/ember-cli/broccoli-es6modules/dev-status.svg)](https://david-dm.org/ember-cli/broccoli-es6modules#info=devDependencies)
+
 ES6Modules is a broccoli filter that transpiles source code in a
 project from ES6 modules to ES5 modules in AMD, CJS, or UMD styles.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-es6modules",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An es6 module transpiler & concatenator for broccoli.",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "dependencies": {
     "broccoli-caching-writer": "0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.7",
-    "esperanto": "^0.7.2",
+    "esperanto": "^0.7.3",
     "mkdirp": "^0.5.0",
     "rsvp": "^3.0.16",
     "walk-sync": "^0.1.3"


### PR DESCRIPTION
Esperanto just merged in [a fix for top-level `this`](https://github.com/esperantojs/esperanto/issues/151), and released a `v0.7.3`. At @stefanpenner's suggestion, I'm bumping the version to ensure consumers are prompted to upgrade if they're currently using `v0.7.2` (and broccoli-es6modules `v1.0.0`)