### PR TITLE
Allow customizing module name for namedAmd with function

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,39 @@ Because this strategy combined with UMD would result in _many_ properties being 
 the `window` object in the browser, `umd` format will throw an error if used without also
 providing `bundleOptions`.
 
+### formatModuleName
+
+An optional function for `namedAmd` module format to customize the module name passed to esperanto.
+
+For example if you have `foo/bar.js`:
+
+```
+export default function() {
+}
+```
+
+and a `formatModuleName` option of:
+
+```
+formatModuleName: function(moduleName) {
+  return moduleName.replace('foo/', '');
+}
+```
+
+
+Esperanto will give you:
+
+```
+define('bar', ['exports'], function(exports) {
+
+  'use strict';
+
+  exports['default'] = function() {
+  }
+
+});
+```
+
 ### esperantoOptions
 ES6Modules wraps the [esperanto](http://esperantojs.org/) library. All [options described for
 esperanto](https://github.com/esperantojs/esperanto/wiki/Converting-a-single-module#options)

--- a/index.js
+++ b/index.js
@@ -245,6 +245,9 @@ module.exports = CachingWriter.extend({
     var options = {};
 
     if (this.format === 'namedAmd') {
+      if (typeof this.formatModuleName === 'function') {
+          moduleName = this.formatModuleName(moduleName);
+      }
       options.amdName = moduleName;
     }
 

--- a/test/expected/namedAmdCustom/subdir/custom-name.js
+++ b/test/expected/namedAmdCustom/subdir/custom-name.js
@@ -1,0 +1,8 @@
+define('custom-name', ['exports'], function (exports) {
+
+	'use strict';
+
+	exports['default'] = function() {
+	}
+
+});

--- a/test/fixtures/subdir/custom-name.js
+++ b/test/fixtures/subdir/custom-name.js
@@ -1,0 +1,2 @@
+export default function() {
+}

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,24 @@ describe('broccoli-es6modules', function() {
     });
   });
 
+  it('allows customizing namedAmd module name with function', function() {
+    var tree = new ES6(fixtures, {
+      format: 'namedAmd',
+      formatModuleName: function(moduleName) {
+        return moduleName.replace('subdir/', '');
+      },
+      esperantoOptions: {
+        strict: true,
+        absolutePaths: true
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(result) {
+      expectFile('subdir/custom-name.js', 'namedAmdCustom').in(result);
+    });
+  });
+
   it('sets sourceMapSource if source maps are enabled', function() {
     var tree = new ES6(fixtures, {
       esperantoOptions: {


### PR DESCRIPTION
In my project I have a structure such as:

```
src/
  - server side code
src/client/
  - app
  - lib
  - assets
  - tests
```

When setting up broccoli trees for this project, I'm rooting them to `src/client` and passing globs based with each subdirectory (eg. `app/**/*.js`, `lib/**/*.js`, etc). However, I do _not_ want my modules to start with `app`. In the past I've made this work by changing how I specify the tree for `app`, by rooting it to `src/client/app` instead of `src/client`. However, this means I have an inconsistency in my code just for 1 plugin. By using this function I can replace `app` from my module names without having to change how my trees are setup.